### PR TITLE
optimise filterMaf task memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed to use DeepTumour 3.0.5, included improvements in upstream
 ### Added
 - Added filterMaf and filterVcf tasks
+
+## [1.0.6] - 2025-10-08
+### Changed
+- Optimized filterMaf memory usage
+
+## [1.0.7] - 2025-10-09
+### Added
+- Added provision out filterd vcf file

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Parameter|Value|Default|Description
 Parameter|Value|Default|Description
 ---|---|---|---
 `filterMaf.t_depth`|Int|1|tumour depth filter threshold
-`filterMaf.t_vaf`|Float|0.01|Tumor Variant Allele Frequency threshold
+`filterMaf.t_vaf`|Float|0.1|Tumor Variant Allele Frequency threshold
 `filterMaf.gnomad_af`|Float|0.001|gnomAD allele frequency threshold
 `filterMaf.valid_exonic`|Array[String]|["5'Flank", "Frame_Shift_Del", "Frame_Shift_Ins", "In_Frame_Del", "In_Frame_Ins", "Missense_Mutation", "Nonsense_Mutation", "Nonstop_Mutation", "Silent", "Splice_Region", "Splice_Site", "Targeted_Region", "Translation_Start_Site"]|list of exonic variants to keep
 `filterMaf.exclude_mutations`|Array[String]|["str_contraction", "t_lod_fstar"]|list of exonic variants to exclude
@@ -59,79 +59,81 @@ Parameter|Value|Default|Description
 Output | Type | Description | Labels
 ---|---|---|---
 `deepTumourOutputJson`|File|the output json assigns a match probability from 0.0 to 1.0 for each of the 29 tumour types on which it was trained and chooses the tumour type with the highest probability score. The algorithm also calculates a type of confidence score based on the probability scores' distributione. A low entropy (< 2.0) is considered a confident score. HIgher values are unreliable (but might be correct).|vidarr_label: deepTumourOutputJson
+`filteredVcFile`|File|the filtered vcf file as input of deepTumour, provision out for inspection|vidarr_label: filteredVcFile
+
 
 ## Commands
-This section lists command(s) run by deepTumour workflow
-
-* Running deepTumour
-
-```
-        # --- Step 1: filter MAF with criteria ---
-        python3 <<CODE
-        import csv
-        import gzip
-
-        output_bed = "filter.bed"
-        open_func = gzip.open if "~{maf_file}".endswith(".gz") else open
-        with open_func("~{maf_file}", "rt") as maf, open(output_bed, "w") as out:
-            reader = csv.DictReader((l for l in maf if not l.startswith("#")), delimiter="\t")
-
-            for row in reader:
-                try:
-                    t_depth = int(row.get("t_depth", 0))
-                    t_alt = int(row.get("t_alt_count", 0))
-                    af = float(row.get("gnomAD_AF", "0") or "0")
-                except ValueError:
-                    continue
-
-                if (
-                    af < ~{gnomad_af}
-                    and row["Variant_Classification"] in "~{sep=',' valid_exonic}"
-                    and row["Variant_Classification"] not in "~{sep=',' exclude_mutations}"
-                    and t_depth > ~{t_depth}
-                    and (t_alt / t_depth) > ~{t_vaf}
-                ):
-                    chrom = row["Chromosome"]
-                    start = int(row["Start_Position"]) - 1
-                    end = int(row["End_Position"])
-                    out.write(f"{chrom}\t{start}\t{end}\n")
-        CODE
-
-        # --- Step 2: apply BED filter to original VCF ---
-        # Extract tumour/normal names
-        grep "^##tumor_sample" ~{vcf_file} | cut -d '=' -f2 > samples.txt
-        grep "^##normal_sample" ~{vcf_file} | cut -d '=' -f2 >> samples.txt
-
-        # Subset VCF to variants in BED + reorder samples
-        bcftools view -f PASS -S samples.txt -R "$PWD/filter.bed" ~{vcf_file} -Oz -o filtered.vcf.gz
-
-```
-```
-        set -euo pipefail
-
-        # extract tumour/normal names from header
-        zcat ~{vcf_file}|grep "^##tumor_sample"|cut -d '=' -f2 > samples.txt
-        zcat ~{vcf_file}|grep "^##normal_sample"|cut -d '=' -f2 >> samples.txt
-
-        # Filter chain:
-        #   1. Keep PASS only
-        #   2. Reorder samples to Normal, Tumour
-        #   3. Filter on tumour depth
-        #   4. Filter on tumour VAF
-        bcftools view -f PASS -S samples.txt ~{vcf_file} -Ou \
-          | bcftools filter -i "(FORMAT/DP[1]) >= ~{t_depth}" -Ou \
-          | bcftools filter -i "(FORMAT/AD[1:1])/(FORMAT/DP[1]) >= ~{t_vaf}" -Oz -o filtered.vcf.gz
-```
-```
-        set -euo pipefail
-
-        mkdir out
-        source $DEEP_TUMOUR_ROOT/.venv/bin/activate
-        python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input
-        mv out/predictions_DeepTumour.json ~{outputFileNamePrefix}.predictions_DeepTumour.json
-
-```
-## Support
+ This section lists command(s) run by deepTumour workflow
+ 
+ * Running deepTumour
+ 
+ ```
+         # --- Step 1: filter MAF with criteria ---
+         python3 <<CODE
+         import csv
+         import gzip
+ 
+         output_bed = "filter.bed"
+         open_func = gzip.open if "~{maf_file}".endswith(".gz") else open
+         with open_func("~{maf_file}", "rt") as maf, open(output_bed, "w") as out:
+             reader = csv.DictReader((l for l in maf if not l.startswith("#")), delimiter="\t")
+ 
+             for row in reader:
+                 try:
+                     t_depth = int(row.get("t_depth", 0))
+                     t_alt = int(row.get("t_alt_count", 0))
+                     af = float(row.get("gnomAD_AF", "0") or "0")
+                 except ValueError:
+                     continue
+ 
+                 if (
+                     af < ~{gnomad_af}
+                     and row["Variant_Classification"] in "~{sep=',' valid_exonic}"
+                     and row["Variant_Classification"] not in "~{sep=',' exclude_mutations}"
+                     and t_depth > ~{t_depth}
+                     and (t_alt / t_depth) > ~{t_vaf}
+                 ):
+                     chrom = row["Chromosome"]
+                     start = int(row["Start_Position"]) - 1
+                     end = int(row["End_Position"])
+                     out.write(f"{chrom}\t{start}\t{end}\n")
+         CODE
+ 
+         # --- Step 2: apply BED filter to original VCF ---
+         # Extract tumour/normal names
+         grep "^##tumor_sample" ~{vcf_file} | cut -d '=' -f2 > samples.txt
+         grep "^##normal_sample" ~{vcf_file} | cut -d '=' -f2 >> samples.txt
+ 
+         # Subset VCF to variants in BED + reorder samples
+         bcftools view -f PASS -S samples.txt -R "$PWD/filter.bed" ~{vcf_file} -Oz -o filtered.vcf.gz
+ 
+ ```
+ ```
+         set -euo pipefail
+ 
+         # extract tumour/normal names from header
+         zcat ~{vcf_file}|grep "^##tumor_sample"|cut -d '=' -f2 > samples.txt
+         zcat ~{vcf_file}|grep "^##normal_sample"|cut -d '=' -f2 >> samples.txt
+ 
+         # Filter chain:
+         #   1. Keep PASS only
+         #   2. Reorder samples to Normal, Tumour
+         #   3. Filter on tumour depth
+         #   4. Filter on tumour VAF
+         bcftools view -f PASS -S samples.txt ~{vcf_file} -Ou \
+           | bcftools filter -i "(FORMAT/DP[1]) >= ~{t_depth}" -Ou \
+           | bcftools filter -i "(FORMAT/AD[1:1])/(FORMAT/DP[1]) >= ~{t_vaf}" -Oz -o filtered.vcf.gz
+ ```
+ ```
+         set -euo pipefail
+ 
+         mkdir out
+         source $DEEP_TUMOUR_ROOT/.venv/bin/activate
+         python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input
+         mv out/predictions_DeepTumour.json ~{outputFileNamePrefix}.predictions_DeepTumour.json
+ 
+ ```
+ ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/commands.txt
+++ b/commands.txt
@@ -5,36 +5,34 @@ This section lists command(s) run by deepTumour workflow
 
 ```
         # --- Step 1: filter MAF with criteria ---
-        python3<<CODE
-        import pandas as pd
-        import os
+        python3 <<CODE
+        import csv
+        import gzip
 
-        df = pd.read_csv("~{maf_file}", sep="\t", comment="#", low_memory=False)
+        output_bed = "filter.bed"
+        open_func = gzip.open if "~{maf_file}".endswith(".gz") else open
+        with open_func("~{maf_file}", "rt") as maf, open(output_bed, "w") as out:
+            reader = csv.DictReader((l for l in maf if not l.startswith("#")), delimiter="\t")
 
-        def safe_float(x):
-            try: return float(x)
-            except: return None
+            for row in reader:
+                try:
+                    t_depth = int(row.get("t_depth", 0))
+                    t_alt = int(row.get("t_alt_count", 0))
+                    af = float(row.get("gnomAD_AF", "0") or "0")
+                except ValueError:
+                    continue
 
-        df["gnomAD_AF"] = df["gnomAD_AF"].apply(safe_float)
-        valid_exonic_list = "~{sep=',' valid_exonic}".split(",")
-        exclude_mutations_list = "~{sep=',' exclude_mutations}".split(",")
-
-        filtered = df[
-            (df["gnomAD_AF"].notna()) &
-            (df["gnomAD_AF"] < ~{gnomad_af}) &
-            (df["Variant_Classification"].isin(valid_exonic_list)) &
-            (~df["Variant_Classification"].isin(exclude_mutations_list)) &
-            (df["t_depth"] > ~{t_depth}) &
-            (df["t_alt_count"] / df["t_depth"] > ~{t_vaf})
-        ]
-
-        bed_df = filtered[["Chromosome","Start_Position","End_Position"]].copy()
-        bed_df["Start_Position"] = bed_df["Start_Position"] - 1
-
-        
-        bed_path = os.path.join(os.getcwd(), "filter.bed")
-        bed_df.to_csv(bed_path, sep="\t", index=False, header=False)
-
+                if (
+                    af < ~{gnomad_af}
+                    and row["Variant_Classification"] in "~{sep=',' valid_exonic}"
+                    and row["Variant_Classification"] not in "~{sep=',' exclude_mutations}"
+                    and t_depth > ~{t_depth}
+                    and (t_alt / t_depth) > ~{t_vaf}
+                ):
+                    chrom = row["Chromosome"]
+                    start = int(row["Start_Position"]) - 1
+                    end = int(row["End_Position"])
+                    out.write(f"{chrom}\t{start}\t{end}\n")
         CODE
 
         # --- Step 2: apply BED filter to original VCF ---

--- a/deepTumour.wdl
+++ b/deepTumour.wdl
@@ -57,11 +57,16 @@ workflow deepTumour {
         deepTumourOutputJson: {
             description: "the output json assigns a match probability from 0.0 to 1.0 for each of the 29 tumour types on which it was trained and chooses the tumour type with the highest probability score. The algorithm also calculates a type of confidence score based on the probability scores' distributione. A low entropy (< 2.0) is considered a confident score. HIgher values are unreliable (but might be correct).",
             vidarr_label: "deepTumourOutputJson"
+        },
+        filteredVcFile: {
+            description: "the filtered vcf file as input of deepTumour, provision out for inspection",
+            vidarr_label: "filteredVcFile"
         }
       }
     }
     output {
         File deepTumourOutputJson = runDeepTumour.outputJson
+        File filteredVcFile = select_first([filterMaf.vcf_filtered, filterVcf.vcf_filtered])
     }
 }
 
@@ -71,7 +76,7 @@ task filterMaf {
         File vcf_file
         File vcf_index
         Int t_depth = 1
-        Float t_vaf = 0.01
+        Float t_vaf = 0.1
         Float gnomad_af = 0.001
         Array[String] valid_exonic = ["5'Flank","Frame_Shift_Del","Frame_Shift_Ins","In_Frame_Del","In_Frame_Ins",
             "Missense_Mutation","Nonsense_Mutation","Nonstop_Mutation","Silent",

--- a/deepTumour.wdl
+++ b/deepTumour.wdl
@@ -97,36 +97,34 @@ task filterMaf {
 
     command <<<
         # --- Step 1: filter MAF with criteria ---
-        python3<<CODE
-        import pandas as pd
-        import os
+        python3 <<CODE
+        import csv
+        import gzip
 
-        df = pd.read_csv("~{maf_file}", sep="\t", comment="#", low_memory=False, compression='infer')
+        output_bed = "filter.bed"
+        open_func = gzip.open if "~{maf_file}".endswith(".gz") else open
+        with open_func("~{maf_file}", "rt") as maf, open(output_bed, "w") as out:
+            reader = csv.DictReader((l for l in maf if not l.startswith("#")), delimiter="\t")
 
-        def safe_float(x):
-            try: return float(x)
-            except: return None
+            for row in reader:
+                try:
+                    t_depth = int(row.get("t_depth", 0))
+                    t_alt = int(row.get("t_alt_count", 0))
+                    af = float(row.get("gnomAD_AF", "0") or "0")
+                except ValueError:
+                    continue
 
-        df["gnomAD_AF"] = df["gnomAD_AF"].apply(safe_float)
-        valid_exonic_list = "~{sep=',' valid_exonic}".split(",")
-        exclude_mutations_list = "~{sep=',' exclude_mutations}".split(",")
-
-        filtered = df[
-            (df["gnomAD_AF"].notna()) &
-            (df["gnomAD_AF"] < ~{gnomad_af}) &
-            (df["Variant_Classification"].isin(valid_exonic_list)) &
-            (~df["Variant_Classification"].isin(exclude_mutations_list)) &
-            (df["t_depth"] > ~{t_depth}) &
-            (df["t_alt_count"] / df["t_depth"] > ~{t_vaf})
-        ]
-
-        bed_df = filtered[["Chromosome","Start_Position","End_Position"]].copy()
-        bed_df["Start_Position"] = bed_df["Start_Position"] - 1
-
-        
-        bed_path = os.path.join(os.getcwd(), "filter.bed")
-        bed_df.to_csv(bed_path, sep="\t", index=False, header=False)
-
+                if (
+                    af < ~{gnomad_af}
+                    and row["Variant_Classification"] in "~{sep=',' valid_exonic}"
+                    and row["Variant_Classification"] not in "~{sep=',' exclude_mutations}"
+                    and t_depth > ~{t_depth}
+                    and (t_alt / t_depth) > ~{t_vaf}
+                ):
+                    chrom = row["Chromosome"]
+                    start = int(row["Start_Position"]) - 1
+                    end = int(row["End_Position"])
+                    out.write(f"{chrom}\t{start}\t{end}\n")
         CODE
 
         # --- Step 2: apply BED filter to original VCF ---

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -37,7 +37,7 @@
                         },
                         "type": "EXTERNAL"
             },
-            "deepTumour.outputFileNamePrefix": "Test2",
+            "deepTumour.outputFileNamePrefix": "test_maf",
             "deepTumour.reference": "hg38",
             "deepTumour.filter_method": "maf",
             "deepTumour.filterMaf.t_depth": null,
@@ -67,7 +67,15 @@
             "deepTumour.deepTumourOutputJson": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_1_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_maf_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "deepTumour.filteredVcFile": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_maf_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -77,7 +85,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/deepTumour/output_metrics/workflow_test_01.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/deepTumour/output_metrics/workflow_test_maf.metrics",
                 "type": "script"
             }
         ]
@@ -109,7 +117,7 @@
                         "type": "EXTERNAL"
             },
             "deepTumour.inputMaf": null,
-            "deepTumour.outputFileNamePrefix": "Test_vcf",
+            "deepTumour.outputFileNamePrefix": "test_vcf",
             "deepTumour.reference": "hg38",
             "deepTumour.filter_method": "vcf",
             "deepTumour.filterMaf.t_depth": null,
@@ -139,7 +147,15 @@
             "deepTumour.deepTumourOutputJson": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_2_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_vcf_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "deepTumour.filteredVcFile": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_vcf_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -149,7 +165,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/deepTumour/output_metrics/workflow_test_02.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/deepTumour/output_metrics/workflow_test_vcf.metrics",
                 "type": "script"
             }
         ]


### PR DESCRIPTION
As there are large maf files not suitable holding in the memory, use csv.DictReader to process file as stream.
Tested can run on 797M maf file without increase memory.