### PR TITLE
adding version 3.0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.7] - 2025-10-09
 ### Added
 - Added provision out filterd vcf file
+
+## [1.0.8] - 2026-04-10
+### Added
+- Added multiple steps filtering
+### Removed
+- removed maf as input and filterMaf task

--- a/README.md
+++ b/README.md
@@ -25,31 +25,29 @@ Parameter|Value|Description
 `inputVcfIndex`|File|index of input vcf
 `outputFileNamePrefix`|String|Prefix for output files
 `reference`|String|The genome reference build. For example: hg19, hg38
-`filter_method`|String|method to filter input vcf directly or filter using maf, value can only be either 'maf' or 'vcf'
 
 
 #### Optional workflow parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
-`inputMaf`|File?|None|the input maf file
+`min_variants`|Int|1000|Minimum number of SNPs required after filtering to run DeepTumour (default 1000)
+`max_variants`|Int|5000|Maximum number of SNPs allowed after filtering to run DeepTumour (default 5000)
 
 
 #### Optional task parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
-`filterMaf.t_depth`|Int|1|tumour depth filter threshold
-`filterMaf.t_vaf`|Float|0.1|Tumor Variant Allele Frequency threshold
-`filterMaf.gnomad_af`|Float|0.001|gnomAD allele frequency threshold
-`filterMaf.valid_exonic`|Array[String]|["5'Flank", "Frame_Shift_Del", "Frame_Shift_Ins", "In_Frame_Del", "In_Frame_Ins", "Missense_Mutation", "Nonsense_Mutation", "Nonstop_Mutation", "Silent", "Splice_Region", "Splice_Site", "Targeted_Region", "Translation_Start_Site"]|list of exonic variants to keep
-`filterMaf.exclude_mutations`|Array[String]|["str_contraction", "t_lod_fstar"]|list of exonic variants to exclude
-`filterMaf.modules`|String|"pandas/2.1.3 bcftools/1.9"|Required environment modules
-`filterMaf.jobMemory`|Int|24|Memory allocated indexing job
-`filterMaf.timeout`|Int|2|Hours before task timeout
-`filterVcf.t_depth`|Int|1|tumour depth filter threshold
-`filterVcf.t_vaf`|Float|0.01|Tumor Variant Allele Frequency threshold
-`filterVcf.modules`|String|"bcftools/1.9"|Required environment modules
-`filterVcf.jobMemory`|Int|8|Memory allocated indexing job
-`filterVcf.timeout`|Int|1|Hours before task timeout
+`filterVcf.repeat_bed`|File|"/.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/bed_files/hg38.repeat_regions.merged.bgzip.bed.gz"|Merged repeat regions BED file (bgzipped, hg38)
+`filterVcf.repeat_bed_idx`|File|"/.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/bed_files/hg38.repeat_regions.merged.bgzip.bed.gz.tbi"|Tabix index for repeat_bed
+`filterVcf.t_vaf`|Float|0.15|Minimum tumor VAF (default 0.15)
+`filterVcf.n_vaf`|Float|0.03|Maximum normal VAF — variants above this are excluded (default 0.03)
+`filterVcf.mmq_threshold`|Int|40|Minimum alt allele median mapping quality (default 40)
+`filterVcf.cluster_window`|Int|10|Window size in bp for clustered SNV exclusion (default 10)
+`filterVcf.cluster_count`|Int|3|Min SNVs in window to trigger cluster exclusion (default 3)
+`filterVcf.indel_proximity`|Int|5|Exclude SNVs within this many bp of an indel (default 5)
+`filterVcf.modules`|String|"bcftools/1.9 python/3.10.6"|Required environment modules
+`filterVcf.jobMemory`|Int|24|Memory allocated to job
+`filterVcf.timeout`|Int|4|Hours before task timeout
 `runDeepTumour.jobMemory`|Int|16|Memory allocated indexing job
 `runDeepTumour.timeout`|Int|4|Hours before task timeout
 
@@ -58,73 +56,142 @@ Parameter|Value|Default|Description
 
 Output | Type | Description | Labels
 ---|---|---|---
-`deepTumourOutputJson`|File|the output json assigns a match probability from 0.0 to 1.0 for each of the 29 tumour types on which it was trained and chooses the tumour type with the highest probability score. The algorithm also calculates a type of confidence score based on the probability scores' distributione. A low entropy (< 2.0) is considered a confident score. HIgher values are unreliable (but might be correct).|vidarr_label: deepTumourOutputJson
-`filteredVcFile`|File|the filtered vcf file as input of deepTumour, provision out for inspection|vidarr_label: filteredVcFile
+`deepTumourOutputJson`|File?|the output json assigns a match probability from 0.0 to 1.0 for each of the 29 tumour types on which it was trained and chooses the tumour type with the highest probability score. The algorithm also calculates a type of confidence score based on the probability scores' distributione. A low entropy (< 2.0) is considered a confident score. HIgher values are unreliable (but might be correct).|vidarr_label: deepTumourOutputJson
+`filtered_vcf`|File|the filtered vcf file as input of deepTumour, provision out for inspection|vidarr_label: filteredVcf
+`snp_count_after_filter`|File|text file containing the number of SNPs remaining after filtering, used to determine whether DeepTumour is run|vidarr_label: snpCountAfterFilter
 
 
 ## Commands
- This section lists command(s) run by deepTumour workflow
+ This section lists command(s) run by WORKFLOW workflow
  
- * Running deepTumour
+ * Running WORKFLOW
  
- ```
-         # --- Step 1: filter MAF with criteria ---
+ === Description here ===.
+ 
+ <<<
+        set -euo pipefail
+ 
+         echo "=== Step 1: bcftools filters ===" >&2
+ 
+         # Extract sample names safely — grep -m1 causes SIGPIPE with set -o pipefail
+         set +o pipefail
+         TUMOR=$(zcat ~{vcf_file} | grep -m1 "^##tumor_sample"  | cut -d'=' -f2 | tr -d '\r')
+         NORMAL=$(zcat ~{vcf_file} | grep -m1 "^##normal_sample" | cut -d'=' -f2 | tr -d '\r')
+         set -o pipefail
+ 
+         echo "Tumor:  $TUMOR" >&2
+         echo "Normal: $NORMAL" >&2
+ 
+         if [ -z "$TUMOR" ] || [ -z "$NORMAL" ]; then
+             echo "ERROR: Could not extract tumor/normal sample names from VCF header" >&2
+             exit 1
+         fi
+ 
+         bcftools view -f PASS ~{vcf_file} \
+         | bcftools view -s "${TUMOR},${NORMAL}" \
+         | bcftools filter \
+             -i "FORMAT/AF[0:0] >= ~{t_vaf}
+                 && FORMAT/AF[1:0] < ~{n_vaf}
+                 && INFO/MMQ[1] >= 40" \
+         | bcftools view -T ^~{repeat_bed} \
+         -Oz -o prefiltered.vcf.gz
+ 
+         bcftools index -t prefiltered.vcf.gz
+         
+         echo "After bcftools filters:" >&2
+         bcftools stats prefiltered.vcf.gz | grep "^SN" >&2
+ 
+         echo "=== Step 2: clustered SNV + indel proximity filter ===" >&2
+ 
+         # Extract SNP positions and indel positions separately
+         bcftools view -v snps prefiltered.vcf.gz \
+           | bcftools query -f '%CHROM\t%POS\n' > snp_positions.txt
+         bcftools view -v indels prefiltered.vcf.gz \
+           | bcftools query -f '%CHROM\t%POS\n' > indel_positions.txt
+ 
+         echo "SNPs before clustering/indel filter: $(wc -l < snp_positions.txt)" >&2
+         echo "Indels (for proximity filter): $(wc -l < indel_positions.txt)" >&2
+ 
          python3 <<CODE
-         import csv
-         import gzip
+ import sys
+ from collections import defaultdict
  
-         output_bed = "filter.bed"
-         open_func = gzip.open if "~{maf_file}".endswith(".gz") else open
-         with open_func("~{maf_file}", "rt") as maf, open(output_bed, "w") as out:
-             reader = csv.DictReader((l for l in maf if not l.startswith("#")), delimiter="\t")
+ clust_win  = ~{cluster_window}
+ clust_cnt  = ~{cluster_count}
+ indel_prox = ~{indel_proximity}
  
-             for row in reader:
-                 try:
-                     t_depth = int(row.get("t_depth", 0))
-                     t_alt = int(row.get("t_alt_count", 0))
-                     af = float(row.get("gnomAD_AF", "0") or "0")
-                 except ValueError:
-                     continue
+ # Load SNP positions
+ snp_positions = defaultdict(list)
+ with open("snp_positions.txt") as f:
+     for line in f:
+         chrom, pos = line.strip().split("\t")
+         snp_positions[chrom].append(int(pos))
  
-                 if (
-                     af < ~{gnomad_af}
-                     and row["Variant_Classification"] in "~{sep=',' valid_exonic}"
-                     and row["Variant_Classification"] not in "~{sep=',' exclude_mutations}"
-                     and t_depth > ~{t_depth}
-                     and (t_alt / t_depth) > ~{t_vaf}
-                 ):
-                     chrom = row["Chromosome"]
-                     start = int(row["Start_Position"]) - 1
-                     end = int(row["End_Position"])
-                     out.write(f"{chrom}\t{start}\t{end}\n")
-         CODE
+ # Load indel positions
+ indel_positions = defaultdict(list)
+ with open("indel_positions.txt") as f:
+     for line in f:
+         parts = line.strip().split("\t")
+         if len(parts) == 2:
+             indel_positions[parts[0]].append(int(parts[1]))
  
-         # --- Step 2: apply BED filter to original VCF ---
-         # Extract tumour/normal names
-         grep "^##tumor_sample" ~{vcf_file} | cut -d '=' -f2 > samples.txt
-         grep "^##normal_sample" ~{vcf_file} | cut -d '=' -f2 >> samples.txt
+ # Clustered SNV filter
+ def is_clustered(chrom, pos):
+     return sum(1 for p in snp_positions[chrom] if abs(p - pos) <= clust_win) >= clust_cnt
  
-         # Subset VCF to variants in BED + reorder samples
-         bcftools view -f PASS -S samples.txt -R "$PWD/filter.bed" ~{vcf_file} -Oz -o filtered.vcf.gz
+ # Indel proximity filter
+ def near_indel(chrom, pos):
+     return any(abs(pos - ipos) <= indel_prox for ipos in indel_positions.get(chrom, []))
  
- ```
- ```
-         set -euo pipefail
+ n_cluster = 0
+ n_indel   = 0
+ kept = []
+ for chrom, positions in snp_positions.items():
+     for pos in positions:
+         if is_clustered(chrom, pos):
+             n_cluster += 1
+         elif near_indel(chrom, pos):
+             n_indel += 1
+         else:
+             kept.append((chrom, pos))
  
-         # extract tumour/normal names from header
-         zcat ~{vcf_file}|grep "^##tumor_sample"|cut -d '=' -f2 > samples.txt
-         zcat ~{vcf_file}|grep "^##normal_sample"|cut -d '=' -f2 >> samples.txt
+ print(f"Fail clustered SNV:       {n_cluster}", file=sys.stderr)
+ print(f"Fail indel proximity:     {n_indel}", file=sys.stderr)
+ print(f"Pass all filters:         {len(kept)}", file=sys.stderr)
  
-         # Filter chain:
-         #   1. Keep PASS only
-         #   2. Reorder samples to Normal, Tumour
-         #   3. Filter on tumour depth
-         #   4. Filter on tumour VAF
-         bcftools view -f PASS -S samples.txt ~{vcf_file} -Ou \
-           | bcftools filter -i "(FORMAT/DP[1]) >= ~{t_depth}" -Ou \
-           | bcftools filter -i "(FORMAT/AD[1:1])/(FORMAT/DP[1]) >= ~{t_vaf}" -Oz -o filtered.vcf.gz
- ```
- ```
+ # Write passing positions as BED (0-based)
+ with open("filter.bed", "w") as out:
+     for chrom, pos in kept:
+         out.write(f"{chrom}\t{pos-1}\t{pos}\n")
+ CODE
+ 
+         echo "=== Step 3: extract final VCF ===" >&2
+ 
+         # Extract sample names for correct column ordering
+         set +o pipefail
+         zcat ~{vcf_file} | grep -m1 "^##tumor_sample"  | cut -d '=' -f2 >  samples.txt
+         zcat ~{vcf_file} | grep -m1 "^##normal_sample" | cut -d '=' -f2 >> samples.txt
+         set -o pipefail
+         echo "Samples:" >&2
+         cat samples.txt >&2
+ 
+         bcftools view -S samples.txt -R "$PWD/filter.bed" prefiltered.vcf.gz \
+           -Oz -o filtered.vcf.gz
+         bcftools index -t filtered.vcf.gz
+ 
+         echo "=== Final output ===" >&2
+         bcftools stats filtered.vcf.gz | grep "^SN" >&2
+         FINAL_SNPS=$(bcftools stats filtered.vcf.gz \
+             | grep "^SN" | grep "number of SNPs" | cut -f4)
+         echo "Final SNP count: ${FINAL_SNPS}" >&2
+ 
+         # Write count to file for WDL output
+         echo "${FINAL_SNPS}" > ~{outputFileNamePrefix}.final_snp_count.txt
+         mv filtered.vcf.gz  ~{outputFileNamePrefix}.filtered.vcf.gz
+         mv filtered.vcf.gz.tbi  ~{outputFileNamePrefix}.filtered.vcf.gz.tbi
+ 
+     >>>
+ <<<
          set -euo pipefail
  
          mkdir out
@@ -132,7 +199,7 @@ Output | Type | Description | Labels
          python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input
          mv out/predictions_DeepTumour.json ~{outputFileNamePrefix}.predictions_DeepTumour.json
  
- ```
+     >>>
  ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .

--- a/commands.txt
+++ b/commands.txt
@@ -1,66 +1,134 @@
 ## Commands
-This section lists command(s) run by deepTumour workflow
+This section lists command(s) run by WORKFLOW workflow
 
-* Running deepTumour
+* Running WORKFLOW
 
-```
-        # --- Step 1: filter MAF with criteria ---
+=== Description here ===.
+
+<<<
+       set -euo pipefail
+
+        echo "=== Step 1: bcftools filters ===" >&2
+
+        # Extract sample names safely — grep -m1 causes SIGPIPE with set -o pipefail
+        set +o pipefail
+        TUMOR=$(zcat ~{vcf_file} | grep -m1 "^##tumor_sample"  | cut -d'=' -f2 | tr -d '\r')
+        NORMAL=$(zcat ~{vcf_file} | grep -m1 "^##normal_sample" | cut -d'=' -f2 | tr -d '\r')
+        set -o pipefail
+
+        echo "Tumor:  $TUMOR" >&2
+        echo "Normal: $NORMAL" >&2
+
+        if [ -z "$TUMOR" ] || [ -z "$NORMAL" ]; then
+            echo "ERROR: Could not extract tumor/normal sample names from VCF header" >&2
+            exit 1
+        fi
+
+        bcftools view -f PASS ~{vcf_file} \
+        | bcftools view -s "${TUMOR},${NORMAL}" \
+        | bcftools filter \
+            -i "FORMAT/AF[0:0] >= ~{t_vaf}
+                && FORMAT/AF[1:0] < ~{n_vaf}
+                && INFO/MMQ[1] >= 40" \
+        | bcftools view -T ^~{repeat_bed} \
+        -Oz -o prefiltered.vcf.gz
+
+        bcftools index -t prefiltered.vcf.gz
+        
+        echo "After bcftools filters:" >&2
+        bcftools stats prefiltered.vcf.gz | grep "^SN" >&2
+
+        echo "=== Step 2: clustered SNV + indel proximity filter ===" >&2
+
+        # Extract SNP positions and indel positions separately
+        bcftools view -v snps prefiltered.vcf.gz \
+          | bcftools query -f '%CHROM\t%POS\n' > snp_positions.txt
+        bcftools view -v indels prefiltered.vcf.gz \
+          | bcftools query -f '%CHROM\t%POS\n' > indel_positions.txt
+
+        echo "SNPs before clustering/indel filter: $(wc -l < snp_positions.txt)" >&2
+        echo "Indels (for proximity filter): $(wc -l < indel_positions.txt)" >&2
+
         python3 <<CODE
-        import csv
-        import gzip
+import sys
+from collections import defaultdict
 
-        output_bed = "filter.bed"
-        open_func = gzip.open if "~{maf_file}".endswith(".gz") else open
-        with open_func("~{maf_file}", "rt") as maf, open(output_bed, "w") as out:
-            reader = csv.DictReader((l for l in maf if not l.startswith("#")), delimiter="\t")
+clust_win  = ~{cluster_window}
+clust_cnt  = ~{cluster_count}
+indel_prox = ~{indel_proximity}
 
-            for row in reader:
-                try:
-                    t_depth = int(row.get("t_depth", 0))
-                    t_alt = int(row.get("t_alt_count", 0))
-                    af = float(row.get("gnomAD_AF", "0") or "0")
-                except ValueError:
-                    continue
+# Load SNP positions
+snp_positions = defaultdict(list)
+with open("snp_positions.txt") as f:
+    for line in f:
+        chrom, pos = line.strip().split("\t")
+        snp_positions[chrom].append(int(pos))
 
-                if (
-                    af < ~{gnomad_af}
-                    and row["Variant_Classification"] in "~{sep=',' valid_exonic}"
-                    and row["Variant_Classification"] not in "~{sep=',' exclude_mutations}"
-                    and t_depth > ~{t_depth}
-                    and (t_alt / t_depth) > ~{t_vaf}
-                ):
-                    chrom = row["Chromosome"]
-                    start = int(row["Start_Position"]) - 1
-                    end = int(row["End_Position"])
-                    out.write(f"{chrom}\t{start}\t{end}\n")
-        CODE
+# Load indel positions
+indel_positions = defaultdict(list)
+with open("indel_positions.txt") as f:
+    for line in f:
+        parts = line.strip().split("\t")
+        if len(parts) == 2:
+            indel_positions[parts[0]].append(int(parts[1]))
 
-        # --- Step 2: apply BED filter to original VCF ---
-        # Extract tumour/normal names
-        grep "^##tumor_sample" ~{vcf_file} | cut -d '=' -f2 > samples.txt
-        grep "^##normal_sample" ~{vcf_file} | cut -d '=' -f2 >> samples.txt
+# Clustered SNV filter
+def is_clustered(chrom, pos):
+    return sum(1 for p in snp_positions[chrom] if abs(p - pos) <= clust_win) >= clust_cnt
 
-        # Subset VCF to variants in BED + reorder samples
-        bcftools view -f PASS -S samples.txt -R "$PWD/filter.bed" ~{vcf_file} -Oz -o filtered.vcf.gz
+# Indel proximity filter
+def near_indel(chrom, pos):
+    return any(abs(pos - ipos) <= indel_prox for ipos in indel_positions.get(chrom, []))
 
-```
-```
-        set -euo pipefail
+n_cluster = 0
+n_indel   = 0
+kept = []
+for chrom, positions in snp_positions.items():
+    for pos in positions:
+        if is_clustered(chrom, pos):
+            n_cluster += 1
+        elif near_indel(chrom, pos):
+            n_indel += 1
+        else:
+            kept.append((chrom, pos))
 
-        # extract tumour/normal names from header
-        zcat ~{vcf_file}|grep "^##tumor_sample"|cut -d '=' -f2 > samples.txt
-        zcat ~{vcf_file}|grep "^##normal_sample"|cut -d '=' -f2 >> samples.txt
+print(f"Fail clustered SNV:       {n_cluster}", file=sys.stderr)
+print(f"Fail indel proximity:     {n_indel}", file=sys.stderr)
+print(f"Pass all filters:         {len(kept)}", file=sys.stderr)
 
-        # Filter chain:
-        #   1. Keep PASS only
-        #   2. Reorder samples to Normal, Tumour
-        #   3. Filter on tumour depth
-        #   4. Filter on tumour VAF
-        bcftools view -f PASS -S samples.txt ~{vcf_file} -Ou \
-          | bcftools filter -i "(FORMAT/DP[1]) >= ~{t_depth}" -Ou \
-          | bcftools filter -i "(FORMAT/AD[1:1])/(FORMAT/DP[1]) >= ~{t_vaf}" -Oz -o filtered.vcf.gz
-```
-```
+# Write passing positions as BED (0-based)
+with open("filter.bed", "w") as out:
+    for chrom, pos in kept:
+        out.write(f"{chrom}\t{pos-1}\t{pos}\n")
+CODE
+
+        echo "=== Step 3: extract final VCF ===" >&2
+
+        # Extract sample names for correct column ordering
+        set +o pipefail
+        zcat ~{vcf_file} | grep -m1 "^##tumor_sample"  | cut -d '=' -f2 >  samples.txt
+        zcat ~{vcf_file} | grep -m1 "^##normal_sample" | cut -d '=' -f2 >> samples.txt
+        set -o pipefail
+        echo "Samples:" >&2
+        cat samples.txt >&2
+
+        bcftools view -S samples.txt -R "$PWD/filter.bed" prefiltered.vcf.gz \
+          -Oz -o filtered.vcf.gz
+        bcftools index -t filtered.vcf.gz
+
+        echo "=== Final output ===" >&2
+        bcftools stats filtered.vcf.gz | grep "^SN" >&2
+        FINAL_SNPS=$(bcftools stats filtered.vcf.gz \
+            | grep "^SN" | grep "number of SNPs" | cut -f4)
+        echo "Final SNP count: ${FINAL_SNPS}" >&2
+
+        # Write count to file for WDL output
+        echo "${FINAL_SNPS}" > ~{outputFileNamePrefix}.final_snp_count.txt
+        mv filtered.vcf.gz  ~{outputFileNamePrefix}.filtered.vcf.gz
+        mv filtered.vcf.gz.tbi  ~{outputFileNamePrefix}.filtered.vcf.gz.tbi
+
+    >>>
+<<<
         set -euo pipefail
 
         mkdir out
@@ -68,4 +136,4 @@ This section lists command(s) run by deepTumour workflow
         python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input
         mv out/predictions_DeepTumour.json ~{outputFileNamePrefix}.predictions_DeepTumour.json
 
-```
+    >>>

--- a/deepTumour.wdl
+++ b/deepTumour.wdl
@@ -16,6 +16,8 @@ workflow deepTumour {
         inputVcfIndex: "index of input vcf"
         outputFileNamePrefix: "Prefix for output files"
         reference: "The genome reference build. For example: hg19, hg38"
+        min_variants: "Minimum number of SNPs required after filtering to run DeepTumour (default 1000)"
+        max_variants: "Maximum number of SNPs allowed after filtering to run DeepTumour (default 5000)"
     }
 
     call filterVcf {
@@ -53,9 +55,13 @@ workflow deepTumour {
             description: "the output json assigns a match probability from 0.0 to 1.0 for each of the 29 tumour types on which it was trained and chooses the tumour type with the highest probability score. The algorithm also calculates a type of confidence score based on the probability scores' distributione. A low entropy (< 2.0) is considered a confident score. HIgher values are unreliable (but might be correct).",
             vidarr_label: "deepTumourOutputJson"
         },
-        filteredVcFile: {
+        filtered_vcf: {
             description: "the filtered vcf file as input of deepTumour, provision out for inspection",
-            vidarr_label: "filteredVcFile"
+            vidarr_label: "filteredVcf"
+        },
+        snp_count_after_filter: {
+            description: "text file containing the number of SNPs remaining after filtering, used to determine whether DeepTumour is run",
+            vidarr_label: "snpCountAfterFilter"
         }
       }
     }
@@ -86,6 +92,7 @@ task filterVcf {
     parameter_meta {
         vcf_file:        "Input Mutect2 VCF (hg38, gzipped)"
         vcf_index:       "Index of input VCF"
+        outputFileNamePrefix: "Prefix for output files"
         repeat_bed:      "Merged repeat regions BED file (bgzipped, hg38)"
         repeat_bed_idx:  "Tabix index for repeat_bed"
         t_vaf:           "Minimum tumor VAF (default 0.15)"

--- a/deepTumour.wdl
+++ b/deepTumour.wdl
@@ -7,6 +7,8 @@ workflow deepTumour {
         File inputVcfIndex
         String outputFileNamePrefix     
         String reference
+        Int min_variants = 1000
+        Int max_variants = 5000
     }
 
     parameter_meta {
@@ -19,15 +21,21 @@ workflow deepTumour {
     call filterVcf {
         input:
         vcf_file = inputVcf,
-        vcf_index = inputVcfIndex
+        vcf_index = inputVcfIndex,
+        outputFileNamePrefix = outputFileNamePrefix 
     }
-    
-    call runDeepTumour {
-        input:
-        vcf = filterVcf.filtered_vcf,
-        outputFileNamePrefix = outputFileNamePrefix,
-        reference_genome = reference,
-        modules = "deep-tumour/3.0.5.1 hg19/p13 bcftools/1.9"
+
+    Int snp_count = read_int(filterVcf.final_snp_count)
+    Boolean sufficient_variants = snp_count >= min_variants && snp_count <= max_variants
+
+    if (sufficient_variants) {
+        call runDeepTumour {
+            input:
+            vcf = filterVcf.filtered_vcf,
+            outputFileNamePrefix = outputFileNamePrefix,
+            reference_genome = reference,
+            modules = "deep-tumour/3.0.5.1 hg19/p13 bcftools/1.9"
+        }
     }
 
     meta {
@@ -52,7 +60,9 @@ workflow deepTumour {
       }
     }
     output {
-        File deepTumourOutputJson = runDeepTumour.outputJson
+        File? deepTumourOutputJson = runDeepTumour.outputJson
+        File  filtered_vcf      = filterVcf.filtered_vcf
+        File  snp_count_after_filter   = filterVcf.final_snp_count
     }
 }
 
@@ -60,6 +70,7 @@ task filterVcf {
     input {
         File vcf_file
         File vcf_index
+        String outputFileNamePrefix 
         File repeat_bed = "/.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/bed_files/hg38.repeat_regions.merged.bgzip.bed.gz"
         File repeat_bed_idx = "/.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/bed_files/hg38.repeat_regions.merged.bgzip.bed.gz.tbi"
         Float t_vaf = 0.15
@@ -201,6 +212,14 @@ CODE
 
         echo "=== Final output ===" >&2
         bcftools stats filtered.vcf.gz | grep "^SN" >&2
+        FINAL_SNPS=$(bcftools stats filtered.vcf.gz \
+            | grep "^SN" | grep "number of SNPs" | cut -f4)
+        echo "Final SNP count: ${FINAL_SNPS}" >&2
+
+        # Write count to file for WDL output
+        echo "${FINAL_SNPS}" > ~{outputFileNamePrefix}.final_snp_count.txt
+        mv filtered.vcf.gz  ~{outputFileNamePrefix}.filtered.vcf.gz
+        mv filtered.vcf.gz.tbi  ~{outputFileNamePrefix}.filtered.vcf.gz.tbi
 
     >>>
 
@@ -211,9 +230,9 @@ CODE
     }
 
     output {
-        File filtered_vcf     = "filtered.vcf.gz"
-        File filtered_vcf_idx = "filtered.vcf.gz.tbi"
-        File filter_bed       = "filter.bed"
+        File    filtered_vcf         = "~{outputFileNamePrefix}.filtered.vcf.gz"
+        File    filtered_vcf_idx     = "~{outputFileNamePrefix}.filtered.vcf.gz.tbi"
+        File final_snp_count     = "~{outputFileNamePrefix}.final_snp_count.txt"
     }
 }
 

--- a/deepTumour.wdl
+++ b/deepTumour.wdl
@@ -4,45 +4,30 @@ version 1.0
 workflow deepTumour {
     input {
         File inputVcf
-        File? inputVcfIndex
-        File? inputMaf
+        File inputVcfIndex
         String outputFileNamePrefix     
         String reference
-        String filter_method
     }
 
     parameter_meta {
         inputVcf: "The input vcf file"
         inputVcfIndex: "index of input vcf"
-        inputMaf: "the input maf file"
         outputFileNamePrefix: "Prefix for output files"
         reference: "The genome reference build. For example: hg19, hg38"
-        filter_method: "method to filter input vcf directly or filter using maf, value can only be either 'maf' or 'vcf'"
     }
-    if (filter_method == "maf" && defined(inputMaf)) {
-        call filterMaf {
-            input:
-            maf_file = select_first([inputMaf]),
-            vcf_file = inputVcf,
-            vcf_index = inputVcfIndex,
-            outputFileNamePrefix = outputFileNamePrefix 
-        }
+
+    call filterVcf {
+        input:
+        vcf_file = inputVcf,
+        vcf_index = inputVcfIndex
     }
-    if (filter_method == "vcf") {
-        call filterVcf {
-            input:
-            vcf_file = inputVcf,
-            outputFileNamePrefix = outputFileNamePrefix 
-        }
-    }
-    File filteredVcf = select_first([filterMaf.vcf_filtered, filterVcf.vcf_filtered])
     
     call runDeepTumour {
         input:
-        vcf = filteredVcf,
+        vcf = filterVcf.filtered_vcf,
         outputFileNamePrefix = outputFileNamePrefix,
         reference_genome = reference,
-        modules = "deep-tumour/3.0.3.1 hg19/p13 bcftools/1.9"
+        modules = "deep-tumour/3.0.5.1 hg19/p13 bcftools/1.9"
     }
 
     meta {
@@ -51,7 +36,7 @@ workflow deepTumour {
         description: "The DeepTumour algorithm predicts the tissue of origin of a tumour based on the pattern of passenger mutations identified by Whole Genome Sequencing (WGS)."
         dependencies: [
             {
-                name: "deep-tumour/3.0.3.1",
+                name: "deep-tumour/3.0.5",
                 url: "https://github.com/LincolnSteinLab/DeepTumour"
             }
         ]
@@ -68,150 +53,167 @@ workflow deepTumour {
     }
     output {
         File deepTumourOutputJson = runDeepTumour.outputJson
-        File filteredVcFile = select_first([filterMaf.vcf_filtered, filterVcf.vcf_filtered])
-        File preprocess_input = runDeepTumour.preprocess_input
-        File post_liftover_vcf = runDeepTumour.post_liftover_vcf
-    }
-}
-
-task filterMaf {
-    input {
-        File maf_file
-        File vcf_file
-        File? vcf_index
-        String outputFileNamePrefix 
-        Int t_depth = 1
-        Float t_vaf = 0.1
-        Float gnomad_af = 0.001
-        Array[String] valid_exonic = ["5'Flank","Frame_Shift_Del","Frame_Shift_Ins","In_Frame_Del","In_Frame_Ins",
-            "Missense_Mutation","Nonsense_Mutation","Nonstop_Mutation","Silent",
-            "Splice_Region","Splice_Site","Targeted_Region","Translation_Start_Site"]
-        Array[String] exclude_mutations = ["str_contraction", "t_lod_fstar"]
-        String modules = "bcftools/1.9"
-        Int jobMemory = 24
-        Int timeout = 2
-    }
-    parameter_meta {
-        maf_file:  "Input maf file"
-        vcf_file:  "Input vcf file"
-        vcf_index: "index of input vcf"
-        t_depth: "tumour depth filter threshold"
-        t_vaf: "Tumor Variant Allele Frequency threshold"
-        gnomad_af: "gnomAD allele frequency threshold"
-        valid_exonic: "list of exonic variants to keep"
-        exclude_mutations: "list of exonic variants to exclude"
-        jobMemory: "Memory allocated indexing job"
-        modules:   "Required environment modules"
-        timeout:   "Hours before task timeout"   
-    }
-
-    command <<<
-        # --- Step 1: filter MAF with criteria ---
-        python3 <<CODE
-        import csv
-        import gzip
-
-        output_bed = "filter.bed"
-        open_func = gzip.open if "~{maf_file}".endswith(".gz") else open
-        with open_func("~{maf_file}", "rt") as maf, open(output_bed, "w") as out:
-            reader = csv.DictReader((l for l in maf if not l.startswith("#")), delimiter="\t")
-
-            for row in reader:
-                try:
-                    t_depth = int(row.get("t_depth", 0))
-                    t_alt = int(row.get("t_alt_count", 0))
-                    af = float(row.get("gnomAD_AF", "0") or "0")
-                except ValueError:
-                    continue
-
-                if (
-                    af < ~{gnomad_af}
-                    and t_depth > ~{t_depth}
-                    and (t_alt / t_depth) > ~{t_vaf}
-                ):
-                    chrom = row["Chromosome"]
-                    start = int(row["Start_Position"]) - 1
-                    end = int(row["End_Position"])
-                    out.write(f"{chrom}\t{start}\t{end}\n")
-        CODE
-
-        # --- Step 2: apply BED filter to original VCF ---
-        # Extract tumour/normal names
-        cat_vcf() {
-            if [[ $1 == *.gz ]]; then
-                zcat "$1"
-            else
-                cat "$1"
-            fi
-        }
-
-        cat_vcf ~{vcf_file} | head -1000 | grep "^##tumor_sample" | cut -d '=' -f2 > samples.txt
-        cat_vcf ~{vcf_file} | head -1000 | grep "^##normal_sample" | cut -d '=' -f2 >> samples.txt
-
-        # Subset VCF to variants in BED + reorder samples
-        bcftools view -f PASS -S samples.txt -R "$PWD/filter.bed" ~{vcf_file} -Oz -o ~{outputFileNamePrefix}.filtered.vcf.gz
-
-    >>>
-    runtime {
-        memory: "~{jobMemory} GB"
-        modules: "~{modules}"
-        timeout: "~{timeout}"
-    }
-    output {
-        File vcf_filtered = "~{outputFileNamePrefix}.filtered.vcf.gz"
     }
 }
 
 task filterVcf {
     input {
         File vcf_file
-        String outputFileNamePrefix 
-        Int t_depth = 1
-        Float t_vaf = 0.01
-        String modules = "bcftools/1.9"
-        Int jobMemory = 8
-        Int timeout = 1
+        File vcf_index
+        File repeat_bed = "/.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/bed_files/hg38.repeat_regions.merged.bgzip.bed.gz"
+        File repeat_bed_idx = "/.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/bed_files/hg38.repeat_regions.merged.bgzip.bed.gz.tbi"
+        Float t_vaf = 0.15
+        Float n_vaf = 0.03
+        Int mmq_threshold = 40
+        Int cluster_window = 10
+        Int cluster_count = 3
+        Int indel_proximity = 5
+        String modules = "bcftools/1.9 python/3.10.6"
+        Int jobMemory = 24
+        Int timeout = 4
     }
     parameter_meta {
-        vcf_file:  "Input vcf file"
-        t_depth: "tumour depth filter threshold"
-        t_vaf: "Tumor Variant Allele Frequency threshold"
-        jobMemory: "Memory allocated indexing job"
-        modules:   "Required environment modules"
-        timeout:   "Hours before task timeout"
+        vcf_file:        "Input Mutect2 VCF (hg38, gzipped)"
+        vcf_index:       "Index of input VCF"
+        repeat_bed:      "Merged repeat regions BED file (bgzipped, hg38)"
+        repeat_bed_idx:  "Tabix index for repeat_bed"
+        t_vaf:           "Minimum tumor VAF (default 0.15)"
+        n_vaf:           "Maximum normal VAF — variants above this are excluded (default 0.03)"
+        mmq_threshold:   "Minimum alt allele median mapping quality (default 40)"
+        cluster_window:  "Window size in bp for clustered SNV exclusion (default 10)"
+        cluster_count:   "Min SNVs in window to trigger cluster exclusion (default 3)"
+        indel_proximity: "Exclude SNVs within this many bp of an indel (default 5)"
+        jobMemory:       "Memory allocated to job"
+        modules:         "Required environment modules"
+        timeout:         "Hours before task timeout"
     }
 
     command <<<
-        set -euo pipefail
+       set -euo pipefail
 
-        cat_vcf() {
-            if [[ $1 == *.gz ]]; then
-                zcat "$1"
-            else
-                cat "$1"
-            fi
-        }
-        cat_vcf ~{vcf_file} | grep "^#CHROM" | head -1 | awk '{print $11; print $10}' > samples.txt
+        echo "=== Step 1: bcftools filters ===" >&2
+
+        # Extract sample names safely — grep -m1 causes SIGPIPE with set -o pipefail
+        set +o pipefail
+        TUMOR=$(zcat ~{vcf_file} | grep -m1 "^##tumor_sample"  | cut -d'=' -f2 | tr -d '\r')
+        NORMAL=$(zcat ~{vcf_file} | grep -m1 "^##normal_sample" | cut -d'=' -f2 | tr -d '\r')
+        set -o pipefail
+
+        echo "Tumor:  $TUMOR" >&2
+        echo "Normal: $NORMAL" >&2
+
+        if [ -z "$TUMOR" ] || [ -z "$NORMAL" ]; then
+            echo "ERROR: Could not extract tumor/normal sample names from VCF header" >&2
+            exit 1
+        fi
+
+        bcftools view -f PASS ~{vcf_file} \
+        | bcftools view -s "${TUMOR},${NORMAL}" \
+        | bcftools filter \
+            -i "FORMAT/AF[0:0] >= ~{t_vaf}
+                && FORMAT/AF[1:0] < ~{n_vaf}
+                && INFO/MMQ[1] >= 40" \
+        | bcftools view -T ^~{repeat_bed} \
+        -Oz -o prefiltered.vcf.gz
+
+        bcftools index -t prefiltered.vcf.gz
         
+        echo "After bcftools filters:" >&2
+        bcftools stats prefiltered.vcf.gz | grep "^SN" >&2
 
-        # Filter chain:
-        #   1. Keep PASS only
-        #   2. Reorder samples to Normal, Tumour
-        #   3. Filter on tumour depth
-        #   4. Filter on tumour VAF
-        bcftools view -f PASS -S samples.txt ~{vcf_file} -Ou \
-          | bcftools filter -i "(FORMAT/DP[1]) >= ~{t_depth}" -Ou \
-          | bcftools filter -i "(FORMAT/AD[1:1])/(FORMAT/DP[1]) >= ~{t_vaf}" -Oz -o ~{outputFileNamePrefix}.filtered.vcf.gz
+        echo "=== Step 2: clustered SNV + indel proximity filter ===" >&2
+
+        # Extract SNP positions and indel positions separately
+        bcftools view -v snps prefiltered.vcf.gz \
+          | bcftools query -f '%CHROM\t%POS\n' > snp_positions.txt
+        bcftools view -v indels prefiltered.vcf.gz \
+          | bcftools query -f '%CHROM\t%POS\n' > indel_positions.txt
+
+        echo "SNPs before clustering/indel filter: $(wc -l < snp_positions.txt)" >&2
+        echo "Indels (for proximity filter): $(wc -l < indel_positions.txt)" >&2
+
+        python3 <<CODE
+import sys
+from collections import defaultdict
+
+clust_win  = ~{cluster_window}
+clust_cnt  = ~{cluster_count}
+indel_prox = ~{indel_proximity}
+
+# Load SNP positions
+snp_positions = defaultdict(list)
+with open("snp_positions.txt") as f:
+    for line in f:
+        chrom, pos = line.strip().split("\t")
+        snp_positions[chrom].append(int(pos))
+
+# Load indel positions
+indel_positions = defaultdict(list)
+with open("indel_positions.txt") as f:
+    for line in f:
+        parts = line.strip().split("\t")
+        if len(parts) == 2:
+            indel_positions[parts[0]].append(int(parts[1]))
+
+# Clustered SNV filter
+def is_clustered(chrom, pos):
+    return sum(1 for p in snp_positions[chrom] if abs(p - pos) <= clust_win) >= clust_cnt
+
+# Indel proximity filter
+def near_indel(chrom, pos):
+    return any(abs(pos - ipos) <= indel_prox for ipos in indel_positions.get(chrom, []))
+
+n_cluster = 0
+n_indel   = 0
+kept = []
+for chrom, positions in snp_positions.items():
+    for pos in positions:
+        if is_clustered(chrom, pos):
+            n_cluster += 1
+        elif near_indel(chrom, pos):
+            n_indel += 1
+        else:
+            kept.append((chrom, pos))
+
+print(f"Fail clustered SNV:       {n_cluster}", file=sys.stderr)
+print(f"Fail indel proximity:     {n_indel}", file=sys.stderr)
+print(f"Pass all filters:         {len(kept)}", file=sys.stderr)
+
+# Write passing positions as BED (0-based)
+with open("filter.bed", "w") as out:
+    for chrom, pos in kept:
+        out.write(f"{chrom}\t{pos-1}\t{pos}\n")
+CODE
+
+        echo "=== Step 3: extract final VCF ===" >&2
+
+        # Extract sample names for correct column ordering
+        set +o pipefail
+        zcat ~{vcf_file} | grep -m1 "^##tumor_sample"  | cut -d '=' -f2 >  samples.txt
+        zcat ~{vcf_file} | grep -m1 "^##normal_sample" | cut -d '=' -f2 >> samples.txt
+        set -o pipefail
+        echo "Samples:" >&2
+        cat samples.txt >&2
+
+        bcftools view -S samples.txt -R "$PWD/filter.bed" prefiltered.vcf.gz \
+          -Oz -o filtered.vcf.gz
+        bcftools index -t filtered.vcf.gz
+
+        echo "=== Final output ===" >&2
+        bcftools stats filtered.vcf.gz | grep "^SN" >&2
+
     >>>
 
     runtime {
-        memory: "~{jobMemory} GB"
+        memory:  "~{jobMemory} GB"
         modules: "~{modules}"
         timeout: "~{timeout}"
     }
 
     output {
-        File vcf_filtered = "~{outputFileNamePrefix}.filtered.vcf.gz"
+        File filtered_vcf     = "filtered.vcf.gz"
+        File filtered_vcf_idx = "filtered.vcf.gz.tbi"
+        File filter_bed       = "filter.bed"
     }
 }
 
@@ -239,10 +241,9 @@ task runDeepTumour {
 
         mkdir out
         source $DEEP_TUMOUR_ROOT/.venv/bin/activate
-        python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input --save-intermediate
+        python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input
         mv out/predictions_DeepTumour.json ~{outputFileNamePrefix}.predictions_DeepTumour.json
-        mv out/DeepTumour_preprocess_input.csv ~{outputFileNamePrefix}.DeepTumour_preprocess_input.csv
-        mv out/_post_liftover.vcf ~{outputFileNamePrefix}.post_liftover.vcf
+
     >>>
 
     runtime {
@@ -253,8 +254,6 @@ task runDeepTumour {
 
     output {
         File outputJson = "~{outputFileNamePrefix}.predictions_DeepTumour.json"
-        File preprocess_input = "~{outputFileNamePrefix}.DeepTumour_preprocess_input.csv"
-        File post_liftover_vcf = "~{outputFileNamePrefix}.post_liftover.vcf"
     }
 
     meta {

--- a/deepTumour.wdl
+++ b/deepTumour.wdl
@@ -4,7 +4,7 @@ version 1.0
 workflow deepTumour {
     input {
         File inputVcf
-        File inputVcfIndex
+        File? inputVcfIndex
         File? inputMaf
         String outputFileNamePrefix     
         String reference
@@ -24,13 +24,15 @@ workflow deepTumour {
             input:
             maf_file = select_first([inputMaf]),
             vcf_file = inputVcf,
-            vcf_index = inputVcfIndex
+            vcf_index = inputVcfIndex,
+            outputFileNamePrefix = outputFileNamePrefix 
         }
     }
     if (filter_method == "vcf") {
         call filterVcf {
             input:
-            vcf_file = inputVcf
+            vcf_file = inputVcf,
+            outputFileNamePrefix = outputFileNamePrefix 
         }
     }
     File filteredVcf = select_first([filterMaf.vcf_filtered, filterVcf.vcf_filtered])
@@ -40,7 +42,7 @@ workflow deepTumour {
         vcf = filteredVcf,
         outputFileNamePrefix = outputFileNamePrefix,
         reference_genome = reference,
-        modules = "deep-tumour/3.0.5 hg19/p13 bcftools/1.9"
+        modules = "deep-tumour/3.0.3.1 hg19/p13 bcftools/1.9"
     }
 
     meta {
@@ -49,7 +51,7 @@ workflow deepTumour {
         description: "The DeepTumour algorithm predicts the tissue of origin of a tumour based on the pattern of passenger mutations identified by Whole Genome Sequencing (WGS)."
         dependencies: [
             {
-                name: "deep-tumour/3.0.5",
+                name: "deep-tumour/3.0.3.1",
                 url: "https://github.com/LincolnSteinLab/DeepTumour"
             }
         ]
@@ -67,6 +69,8 @@ workflow deepTumour {
     output {
         File deepTumourOutputJson = runDeepTumour.outputJson
         File filteredVcFile = select_first([filterMaf.vcf_filtered, filterVcf.vcf_filtered])
+        File preprocess_input = runDeepTumour.preprocess_input
+        File post_liftover_vcf = runDeepTumour.post_liftover_vcf
     }
 }
 
@@ -74,7 +78,8 @@ task filterMaf {
     input {
         File maf_file
         File vcf_file
-        File vcf_index
+        File? vcf_index
+        String outputFileNamePrefix 
         Int t_depth = 1
         Float t_vaf = 0.1
         Float gnomad_af = 0.001
@@ -82,7 +87,7 @@ task filterMaf {
             "Missense_Mutation","Nonsense_Mutation","Nonstop_Mutation","Silent",
             "Splice_Region","Splice_Site","Targeted_Region","Translation_Start_Site"]
         Array[String] exclude_mutations = ["str_contraction", "t_lod_fstar"]
-        String modules = "pandas/2.1.3 bcftools/1.9"
+        String modules = "bcftools/1.9"
         Int jobMemory = 24
         Int timeout = 2
     }
@@ -121,8 +126,6 @@ task filterMaf {
 
                 if (
                     af < ~{gnomad_af}
-                    and row["Variant_Classification"] in "~{sep=',' valid_exonic}"
-                    and row["Variant_Classification"] not in "~{sep=',' exclude_mutations}"
                     and t_depth > ~{t_depth}
                     and (t_alt / t_depth) > ~{t_vaf}
                 ):
@@ -134,11 +137,19 @@ task filterMaf {
 
         # --- Step 2: apply BED filter to original VCF ---
         # Extract tumour/normal names
-        grep "^##tumor_sample" ~{vcf_file} | cut -d '=' -f2 > samples.txt
-        grep "^##normal_sample" ~{vcf_file} | cut -d '=' -f2 >> samples.txt
+        cat_vcf() {
+            if [[ $1 == *.gz ]]; then
+                zcat "$1"
+            else
+                cat "$1"
+            fi
+        }
+
+        cat_vcf ~{vcf_file} | head -1000 | grep "^##tumor_sample" | cut -d '=' -f2 > samples.txt
+        cat_vcf ~{vcf_file} | head -1000 | grep "^##normal_sample" | cut -d '=' -f2 >> samples.txt
 
         # Subset VCF to variants in BED + reorder samples
-        bcftools view -f PASS -S samples.txt -R "$PWD/filter.bed" ~{vcf_file} -Oz -o filtered.vcf.gz
+        bcftools view -f PASS -S samples.txt -R "$PWD/filter.bed" ~{vcf_file} -Oz -o ~{outputFileNamePrefix}.filtered.vcf.gz
 
     >>>
     runtime {
@@ -147,13 +158,14 @@ task filterMaf {
         timeout: "~{timeout}"
     }
     output {
-        File vcf_filtered = "filtered.vcf.gz"
+        File vcf_filtered = "~{outputFileNamePrefix}.filtered.vcf.gz"
     }
 }
 
 task filterVcf {
     input {
         File vcf_file
+        String outputFileNamePrefix 
         Int t_depth = 1
         Float t_vaf = 0.01
         String modules = "bcftools/1.9"
@@ -172,9 +184,15 @@ task filterVcf {
     command <<<
         set -euo pipefail
 
-        # extract tumour/normal names from header
-        zcat ~{vcf_file}|grep "^##tumor_sample"|cut -d '=' -f2 > samples.txt
-        zcat ~{vcf_file}|grep "^##normal_sample"|cut -d '=' -f2 >> samples.txt
+        cat_vcf() {
+            if [[ $1 == *.gz ]]; then
+                zcat "$1"
+            else
+                cat "$1"
+            fi
+        }
+        cat_vcf ~{vcf_file} | grep "^#CHROM" | head -1 | awk '{print $11; print $10}' > samples.txt
+        
 
         # Filter chain:
         #   1. Keep PASS only
@@ -183,7 +201,7 @@ task filterVcf {
         #   4. Filter on tumour VAF
         bcftools view -f PASS -S samples.txt ~{vcf_file} -Ou \
           | bcftools filter -i "(FORMAT/DP[1]) >= ~{t_depth}" -Ou \
-          | bcftools filter -i "(FORMAT/AD[1:1])/(FORMAT/DP[1]) >= ~{t_vaf}" -Oz -o filtered.vcf.gz
+          | bcftools filter -i "(FORMAT/AD[1:1])/(FORMAT/DP[1]) >= ~{t_vaf}" -Oz -o ~{outputFileNamePrefix}.filtered.vcf.gz
     >>>
 
     runtime {
@@ -193,7 +211,7 @@ task filterVcf {
     }
 
     output {
-        File vcf_filtered = "filtered.vcf.gz"
+        File vcf_filtered = "~{outputFileNamePrefix}.filtered.vcf.gz"
     }
 }
 
@@ -221,9 +239,10 @@ task runDeepTumour {
 
         mkdir out
         source $DEEP_TUMOUR_ROOT/.venv/bin/activate
-        python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input
+        python $DEEP_TUMOUR_ROOT/src/DeepTumour.py --vcfFile ~{vcf} --reference $HG19_ROOT/hg19_random.fa ~{liftover} --outDir out --keep_input --save-intermediate
         mv out/predictions_DeepTumour.json ~{outputFileNamePrefix}.predictions_DeepTumour.json
-
+        mv out/DeepTumour_preprocess_input.csv ~{outputFileNamePrefix}.DeepTumour_preprocess_input.csv
+        mv out/_post_liftover.vcf ~{outputFileNamePrefix}.post_liftover.vcf
     >>>
 
     runtime {
@@ -234,6 +253,8 @@ task runDeepTumour {
 
     output {
         File outputJson = "~{outputFileNamePrefix}.predictions_DeepTumour.json"
+        File preprocess_input = "~{outputFileNamePrefix}.DeepTumour_preprocess_input.csv"
+        File post_liftover_vcf = "~{outputFileNamePrefix}.post_liftover.vcf"
     }
 
     meta {

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -25,111 +25,18 @@
                         },
                         "type": "EXTERNAL"
             },
-            "deepTumour.inputMaf": {
-                        "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/deepTumour/test_inputs/test2_mutect2.filtered.maf.gz",
-                            "externalIds": [
-                                {
-                                    "id": "TEST",
-                                    "provider": "TEST"
-                                }
-                            ]
-                        },
-                        "type": "EXTERNAL"
-            },
-            "deepTumour.outputFileNamePrefix": "test_maf",
-            "deepTumour.reference": "hg38",
-            "deepTumour.filter_method": "maf",
-            "deepTumour.filterMaf.t_depth": null,
-            "deepTumour.filterMaf.t_vaf": null,
-            "deepTumour.filterMaf.gnomad_af": null,
-            "deepTumour.filterMaf.valid_exonic": null,
-            "deepTumour.filterMaf.exclude_mutations": null,
-            "deepTumour.filterMaf.modules": null,
-            "deepTumour.filterMaf.jobMemory": null,
-            "deepTumour.filterMaf.timeout": null,
-            "deepTumour.filterVcf.t_depth": null,
-            "deepTumour.filterVcf.t_vaf": null,
-            "deepTumour.filterVcf.modules": null,
-            "deepTumour.filterVcf.jobMemory": null,
-            "deepTumour.filterVcf.timeout": null,
-            "deepTumour.runDeepTumour.modules": null,
-            "deepTumour.runDeepTumour.jobMemory": null,
-            "deepTumour.runDeepTumour.timeout": null
-        },
-        "description": "deepTumour workflow test filterMaf",
-        "engineArguments": {
-           "write_to_cache": false,
-           "read_from_cache": false
-        },
-        "id": "deepTumour_test_filterMaf",
-        "metadata": {
-            "deepTumour.deepTumourOutputJson": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_maf_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            },
-            "deepTumour.filteredVcFile": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_maf_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            }
-        },
-        "validators": [
-            {
-                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
-                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/deepTumour/output_metrics/workflow_test_maf.metrics",
-                "type": "script"
-            }
-        ]
-    },
-       {
-        "arguments": {
-            "deepTumour.inputVcf": {
-                        "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/deepTumour/test_inputs/Test02.mutect2.filtered.vep.vcf.gz",
-                            "externalIds": [
-                                {
-                                    "id": "TEST",
-                                    "provider": "TEST"
-                                }
-                            ]
-                        },
-                        "type": "EXTERNAL"
-            },
-            "deepTumour.inputVcfIndex": {
-                        "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/deepTumour/test_inputs/Test02.mutect2.filtered.vep.vcf.gz.tbi",
-                            "externalIds": [
-                                {
-                                    "id": "TEST",
-                                    "provider": "TEST"
-                                }
-                            ]
-                        },
-                        "type": "EXTERNAL"
-            },
-            "deepTumour.inputMaf": null,
             "deepTumour.outputFileNamePrefix": "test_vcf",
             "deepTumour.reference": "hg38",
-            "deepTumour.filter_method": "vcf",
-            "deepTumour.filterMaf.t_depth": null,
-            "deepTumour.filterMaf.t_vaf": null,
-            "deepTumour.filterMaf.gnomad_af": null,
-            "deepTumour.filterMaf.valid_exonic": null,
-            "deepTumour.filterMaf.exclude_mutations": null,
-            "deepTumour.filterMaf.modules": null,
-            "deepTumour.filterMaf.jobMemory": null,
-            "deepTumour.filterMaf.timeout": null,
-            "deepTumour.filterVcf.t_depth": null,
+            "deepTumour.min_variants": null,
+            "deepTumour.max_variants": null,
+            "deepTumour.filterVcf.repeat_bed": null,
+            "deepTumour.filterVcf.repeat_bed_idx": null,
             "deepTumour.filterVcf.t_vaf": null,
+            "deepTumour.filterVcf.n_vaf": null,
+            "deepTumour.filterVcf.mmq_threshold": null,
+            "deepTumour.filterVcf.cluster_window": null,
+            "deepTumour.filterVcf.cluster_count": null,
+            "deepTumour.filterVcf.indel_proximity": null,
             "deepTumour.filterVcf.modules": null,
             "deepTumour.filterVcf.jobMemory": null,
             "deepTumour.filterVcf.timeout": null,
@@ -152,7 +59,15 @@
                 ],
                 "type": "ALL"
             },
-            "deepTumour.filteredVcFile": {
+            "deepTumour.filtered_vcf": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_vcf_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "deepTumour.snp_count_after_filter": {
                 "contents": [
                     {
                         "outputDirectory": "@SCRATCH@/@DATE@_Workflow_deepTumour_test_vcf_@JENKINSID@"


### PR DESCRIPTION
1, using DeepTumour 3.0.3 version from original repo, as 3.0.5 appears to have bug
2, modified the forked repo to save vcf after liftover which needs investigating for debugging. In test runs noticed huge amount of warnings generated for liftover caused reference mismatch. I saved the warning messages in  /.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/out2/warn.log, which has 671944 lines.
3, also provision out other files for diagnose purpose like filtered vcf, so this version is more of a dev version
4, test run output example in /.mounts/labs/gsiprojects/gsi/gsiusers/gpeng/workflow/deepTumour/test/out2